### PR TITLE
Unsupported datatype error improvement

### DIFF
--- a/Modules/Write-ObjectToSQL/Write-ObjectToSQL.psm1
+++ b/Modules/Write-ObjectToSQL/Write-ObjectToSQL.psm1
@@ -738,10 +738,10 @@ function Write-ObjectToSQL
         # did the input object contain any supported properties? If not, break the script
         # if no supported properties were found then either $strBuilderColumns or $strBuilderValues (or probably both) will be empty
         if ( !$strBuilderColumns.ToString() ){
-            Throw 'The input object did not contain any supported properties. Unable to generate columns for insert.'
+            Throw "The input object did not contain any supported properties. Unable to generate columns for insert.`nKEY: ""$key"" DATATYPE: ""$datatype"""
         }
         if ( !$strBuilderValues.ToString() ){
-            Throw 'The input object did not contain any supported properties. Unable to generate values for insert.'
+            Throw "The input object did not contain any supported properties. Unable to generate values for insert.`nKEY: ""$key"" DATATYPE: ""$datatype"""
         }
             
         # remove the first two characters which should be a space and a comma in both strings


### PR DESCRIPTION
Often when using Write-ObjectToSql I have datatypes that are unsupported. The current error thrown does not specify the offending key and data type.